### PR TITLE
Ensure unique IDs

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,4 +10,7 @@ But to configure its environment, you should have some basic knowledge of Intern
 
 - [`xonox` at PyPI](https://pypi.org/project/xonox)
 
+## Note to developers
+Make sure that your development environment has [Flask](https://pypi.org/project/Flask/) installed. The unit-tests require [pyfakefs](https://pypi.org/project/pyfakefs/).
+
 (c) 2022 TillW - Licensed to you under the AGPL v3.0

--- a/source/README.md
+++ b/source/README.md
@@ -60,7 +60,10 @@ By default, `xonox` writes its configuration and station-list to a file called `
 
 
 ## Changelog
-### 0.0.5 (Work in Progress)
+### 0.0.6 (Work in Progress)
+- Fixed [non-unique station-IDs](https://github.com/x789/xonox/issues/3)
+
+### 0.0.5
 - __BREAKING CHANGE__ If the service shall bound to a specific ip-address, it must be provided via `--host` and not the positional parameter like in previous versions.
 - Added possibility to configure the location of `xonox.config` via command-line parameter `--config-dir`.
 - Fixed 'config not found'

--- a/source/setup.cfg
+++ b/source/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = xonox
-version = 0.0.5
+version = 0.0.6
 author = TillW
 description = An alternative infrastructure-service for legacy NOXON(tm) devices
 long_description = file: README.md

--- a/source/src/xonox/__init__.py
+++ b/source/src/xonox/__init__.py
@@ -1,0 +1,2 @@
+from .station import Station
+from .station_repository import StationRepository

--- a/source/src/xonox/server.py
+++ b/source/src/xonox/server.py
@@ -52,7 +52,7 @@ def get_station_list():
 def get_station(id):
     try:
         return jsonify(stationRepository.get(id))
-    except IndexError:
+    except KeyError:
         return abort(404)
 
 @app.route('/station/<int:id>', methods=['delete'])
@@ -60,7 +60,7 @@ def delete_station(id):
     try:
         stationRepository.remove(id)
         return Response(status=204)
-    except IndexError:
+    except KeyError:
         return abort(404)
 
 # NOXON(tm) API ##################

--- a/source/src/xonox/server.py
+++ b/source/src/xonox/server.py
@@ -4,8 +4,8 @@
 
 from collections import namedtuple
 from flask import Flask, request, abort, jsonify, json, Response
-from xonox.station import Station
-from xonox.station_repository import StationRepository
+from . import Station
+from . import StationRepository
 
 # WebAPI Helpers #################
 ##################################

--- a/source/src/xonox/server.py
+++ b/source/src/xonox/server.py
@@ -83,7 +83,7 @@ def search_station():
 
 @app.route('/noOp')
 def no_op():
-    return ""
+    return ''
 
 def __create_station_list(stations, baseUri):
     result = '<?xml version="1.0" encoding="iso-8859-1" standalone="yes"?><ListOfItems><ItemCount>-1</ItemCount>'

--- a/source/src/xonox/station.py
+++ b/source/src/xonox/station.py
@@ -3,8 +3,8 @@
 # Licensed to you under Affero GPL 3.0 (https://www.gnu.org/licenses/agpl-3.0.html)
 
 class Station:
-    def __init__(self, name, description, stream):
-        self.id = None
+    def __init__(self, name, description, stream, id = None):
+        self.id = id
         self.name = name
         self.description = description
         self.stream = stream

--- a/source/src/xonox/station_repository.py
+++ b/source/src/xonox/station_repository.py
@@ -5,7 +5,7 @@
 import json
 from pathlib import Path
 from os import path
-from xonox.station import Station
+from . import Station
 
 class StationRepository:
     def __init__(self, configDirectory):

--- a/source/src/xonox/station_repository.py
+++ b/source/src/xonox/station_repository.py
@@ -72,6 +72,6 @@ class StationRepository:
 
     def __write_data_to_file(self):
         if len(self.__data) > 0:
-            config = { 'stations': self.__data }
+            config = { 'stations': self.__data, 'nextStationId': self.__next_station_id }
             with open(self.__configPath, 'w+') as file:
                 json.dump(config, file, default=lambda o: o.__dict__, sort_keys=False, indent=2)

--- a/source/src/xonox/station_repository.py
+++ b/source/src/xonox/station_repository.py
@@ -10,36 +10,65 @@ from . import Station
 class StationRepository:
     def __init__(self, configDirectory):
         self.__data = []
+        self.__next_station_id = 0
         if configDirectory is None:
             configDirectory = Path.home()
         self.__configPath = path.join(configDirectory, 'xonox.conf')
         self.__load_data_from_file()
 
     def add(self, station):
-        station.id = len(self.__data)
+        self.__update_next_station_id(station)
+        self.__ensure_station_id_set(station)
         self.__data.append(station)
         self.__write_data_to_file()
 
     def get(self, id):
-        return self.__data[id]
+        for x in self.__data:
+            if x.id == id:
+                return x
+        raise KeyError()
 
     def get_all(self):
         return self.__data.copy()
 
     def remove(self, id):
-        self.__data.pop(id)
-        self.__write_data_to_file()
+        for x in self.__data:
+            if x.id == id:
+                self.__data.remove(x)
+                self.__write_data_to_file()
+                return
+        raise KeyError()
+
+    def __ensure_station_id_set(self, station):
+        if station.id is None:
+            station.id = self.__next_station_id
+            self.__next_station_id = self.__next_station_id + 1
+
+    def __update_next_station_id(self, station):
+        if station.id is not None and station.id >= self.__next_station_id:
+            self.__next_station_id = station.id + 1
 
     def __load_data_from_file(self):
         try:
             with open(self.__configPath, 'r') as file:
                 config = json.load(file)
-                if ('stations' in config):
-                    stations = config['stations']
-                    for station in stations:
-                        self.add(Station(station['name'], station['description'], station['stream']))
+                self.__read_stations_from_config(config)
+                self.__read_next_station_id_from_config(config)
         except FileNotFoundError:
             pass
+
+    def __read_stations_from_config(self, config):
+        if 'stations' in config:
+            stations = config['stations']
+            for station in stations:
+                self.add(Station(station['name'], station['description'], station['stream']))
+
+    def __read_next_station_id_from_config(self, config):
+        if 'nextStationId' in config:
+            try:
+                self.__next_station_id = int(config['nextStationId'])
+            except ValueError:
+                self.__next_station_id = len(self.__data)
 
     def __write_data_to_file(self):
         if len(self.__data) > 0:

--- a/source/tests/test_station_repository.py
+++ b/source/tests/test_station_repository.py
@@ -1,0 +1,152 @@
+from pyfakefs.fake_filesystem_unittest import TestCase
+from src.xonox.station_repository import StationRepository
+from src.xonox.station import Station
+from os import path
+
+class StationRepositoryTestCase(TestCase):    
+    def setUp(self):
+        self.setUpPyfakefs()
+
+    def test_init_without_config(self):
+        sut = StationRepository(None)
+
+        stations = sut.get_all()
+
+        assert len(stations) == 0
+
+    def test_get_unknown(self):
+        station = Station('foo', 'bar', 'http://example.stream')
+        sut = StationRepository(None)
+        sut.add(station)
+        
+        with self.assertRaises(KeyError):
+            sut.get(29725)
+
+    def test_get_unknown_when_empty(self):
+        sut = StationRepository(None)
+        
+        with self.assertRaises(KeyError):
+            sut.get(0)
+
+    def test_delete(self):
+        station = Station('foo', 'bar', 'http://example.stream')
+        sut = StationRepository(None)
+        sut.add(station)
+
+        sut.remove(0)
+
+        assert len(sut.get_all()) == 0
+
+    def test_delete_unknown(self):
+        station = Station('foo', 'bar', 'http://example.stream')
+        sut = StationRepository(None)
+        sut.add(station)
+
+        with self.assertRaises(KeyError):
+            sut.remove(-10)
+
+    def test_add_new_to_empty(self):
+        station = Station('foo', 'bar', 'http://example.stream')
+        sut = StationRepository(None)
+
+        sut.add(station)
+
+        assert len(sut.get_all()) == 1
+        assert sut.get(0) is not None
+        assert sut.get(0).id == 0
+
+    def test_add_new_to_nonempty(self):
+        sut = StationRepository(None)
+        sut.add(Station('1', 'one', 'http://example.stream/1'))
+
+        sut.add(Station('2', 'two', 'http://example.stream/2'))
+
+        assert len(sut.get_all()) == 2
+        assert sut.get(0) is not None
+        assert sut.get(1) is not None
+        assert sut.get(0).id == 0
+        assert sut.get(0).name is '1'
+        assert sut.get(0).description is 'one'
+        assert sut.get(0).stream is 'http://example.stream/1'
+        assert sut.get(1).id == 1
+        assert sut.get(1).name is '2'
+        assert sut.get(1).description is 'two'
+        assert sut.get(1).stream is 'http://example.stream/2'
+
+    def test_add_old_to_empty(self):
+        station = Station('foo', 'bar', 'http://example.stream', 3597)
+        sut = StationRepository(None)
+
+        sut.add(station)
+
+        assert len(sut.get_all()) == 1
+        assert sut.get(3597) is not None
+    
+    def test_add_old_after_new(self):
+        sut = StationRepository(None)
+        sut.add(Station('1', 'one', 'http://example.stream/1'))
+
+        sut.add(Station('foo', 'bar', 'http://example.stream', 1337))
+
+        assert len(sut.get_all()) == 2
+        assert sut.get(0) is not None
+        assert sut.get(1337) is not None
+        assert sut.get(0).id == 0
+        assert sut.get(0).name is '1'
+        assert sut.get(0).description is 'one'
+        assert sut.get(0).stream is 'http://example.stream/1'
+        assert sut.get(1337).id == 1337
+        assert sut.get(1337).name is 'foo'
+        assert sut.get(1337).description is 'bar'
+        assert sut.get(1337).stream is 'http://example.stream'
+
+    def test_add_new_after_old(self):
+        sut = StationRepository(None)
+        sut.add(Station('foo', 'bar', 'http://example.stream', 1337))
+
+        sut.add(Station('1', 'one', 'http://example.stream/1'))
+
+        assert len(sut.get_all()) == 2
+        assert sut.get(1337) is not None
+        assert sut.get(1338) is not None
+        assert sut.get(1337).id == 1337
+        assert sut.get(1337).name is 'foo'
+        assert sut.get(1337).description is 'bar'
+        assert sut.get(1337).stream is 'http://example.stream'
+        assert sut.get(1338).id == 1338
+        assert sut.get(1338).name is '1'
+        assert sut.get(1338).description is 'one'
+        assert sut.get(1338).stream is 'http://example.stream/1'
+
+    def test_issue_3(self):
+        """Tests the fix for issue #3. See https://github.com/x789/xonox/issues/3 for details."""
+        sut = StationRepository(None)
+        sut.add(Station('Station A', 'AAA', 'http://example.stream/A'))
+        sut.add(Station('Station B', 'BBB', 'http://example.stream/B'))
+        sut.add(Station('Station C', 'CCC', 'http://example.stream/C'))
+        sut.remove(1)
+        
+        sut.add(Station('Station D', 'DDD', 'http://example.stream/D'))
+
+        assert len(sut.get_all()) == 3
+        assert sut.get(0) is not None
+        assert sut.get(2) is not None
+        assert sut.get(3) is not None
+
+    def test_add_colliding_ids(self):
+        """
+        IDs are unique. Before v0.0.6 collisions could occur but there is no automatic solution for that issue. This test is primarily for documentation purpose.
+        See https://github.com/x789/xonox/issues/3 for details.
+        """
+        sut = StationRepository(None)
+        sut.add(Station('foo', 'bar', 'http://example.stream', 15))
+
+        sut.add(Station('1', 'one', 'http://example.stream/1', 15))
+
+        assert len(sut.get_all()) == 2
+        s = sut.get(15)
+        assert s is not None
+        assert s.id == 15
+        assert s.name is 'foo'
+        assert s.description is 'bar'
+        assert s.stream is 'http://example.stream'

--- a/source/tests/test_station_repository.py
+++ b/source/tests/test_station_repository.py
@@ -150,3 +150,19 @@ class StationRepositoryTestCase(TestCase):
         assert s.name is 'foo'
         assert s.description is 'bar'
         assert s.stream is 'http://example.stream'
+
+    def test_persistence_of_id_counter(self):
+        old_repository = StationRepository(None)
+        old_repository.add(Station('foo', 'bar', 'http://example.stream', 15))
+        old_repository.remove(15)
+        sut = StationRepository(None)
+        expected = Station('Radio Tralalala', 'Finest Tralala Music', 'http://metamorphosator.com/stream')
+
+        sut.add(expected)
+
+        assert sut.get(16) is not None
+        actual = sut.get(16)
+        assert actual.id == expected.id
+        assert actual.name == expected.name
+        assert actual.description == expected.description
+        assert actual.stream == expected.stream


### PR DESCRIPTION
The code in this PR ensures that IDs are unique if:
- the config file does not contain duplicates when it is read
- the config file is not tampered by a third party

This PR closes issue #3. 