### PR TITLE
added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3-slim-buster
+
+LABEL version="0.4"
+LABEL description="Dockerfile for xonox backend"
+
+WORKDIR /usr/src/app
+
+
+ADD source /usr/src/app/
+ENV VIRTUAL_ENV=/opt/venv
+RUN python -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip install --upgrade pip
+RUN  pip install .
+EXPOSE 80
+CMD ["python", "-m", "xonox", "--config-dir",  "/usr/src/app"]


### PR DESCRIPTION
zum einfacheren Testen habe ich einen Dockerfile hinzugefügt.
Mit `docker build . ` im Projektverzeichnis kann man das Image erstellen und mit 
`docker run -p 80:80 -v /path/to/xonox/xonox.conf:/usr/src/app/xonox.conf <imageID>` direkt starten.
hilft auch wenn man das ganze hinter einem reverse Proxy auf der gleichen Maschine hat um den Port zu ändern ;)

Ob das Dockerfile für python Projekte so richtig ist weiß ich aber auch nicht. Ist nach besten Wissen und Gewissen entstanden :)
